### PR TITLE
Make the version of rubygems configurable

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,4 +12,9 @@ suites:
   - name: default
     run_list:
       - recipe[brightbox-ruby]
+  - name: rubygems
+    run_list:
+      - recipe[brightbox-ruby]
     attributes:
+      brightbox-ruby:
+        rubygems_version: 2.0.0

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ For more documentation on these builds, please see [the official brightbox docum
 * `node['brightbox-ruby']['version']` - The version of Ruby to install. Defaults to `2.1`.
 * `node['brightbox-ruby']['install_dev_package']` - Install the dev package, which provides headers for gem native extensions. Available options: `true`, `false`. Defaults to `true`.
 * `node['brightbox-ruby']['gems']` - Gems to be installed by default. Defaults to `["bundler", "rake", "rubygems-bundler"]`.
+* `node['brightbox-ruby']['rubygems_version']` - The version of rubygems to enforce. Set to nil to use the default version packaged by brightbox. Defaults to `nil`.
 
 # Recipes
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For more documentation on these builds, please see [the official brightbox docum
 * `node['brightbox-ruby']['version']` - The version of Ruby to install. Defaults to `2.1`.
 * `node['brightbox-ruby']['install_dev_package']` - Install the dev package, which provides headers for gem native extensions. Available options: `true`, `false`. Defaults to `true`.
 * `node['brightbox-ruby']['gems']` - Gems to be installed by default. Defaults to `["bundler", "rake", "rubygems-bundler"]`.
-* `node['brightbox-ruby']['rubygems_version']` - The version of rubygems to enforce. Set to nil to use the default version packaged by brightbox. Defaults to `nil`.
+* `node['brightbox-ruby']['rubygems_version']` - The version of rubygems to enforce, or nil to use the default packaged version. Defaults to ``.
 
 # Recipes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
 default['brightbox-ruby']['default_action'] = :upgrade
 default['brightbox-ruby']['version'] = '2.1'
 default['brightbox-ruby']['install_dev_package'] = true
+default['brightbox-ruby']['rubygems_version'] = nil
 default['brightbox-ruby']['gems'] = ["bundler", "rake", "rubygems-bundler"]

--- a/metadata.rb
+++ b/metadata.rb
@@ -47,6 +47,14 @@ attribute 'brightbox-ruby/gems',
  recipes: ['brightbox-ruby'],
  default: ["bundler", "rake", "rubygems-bundler"]
 
+attribute 'brightbox-ruby/rubygems_version',
+ display_name: 'Rubygems version to enforce',
+ description: 'Rubygems version to enforce',
+ type: 'string',
+ required: 'optional',
+ recipes: ['brightbox-ruby'],
+ default: nil
+
 supports 'ubuntu'
 
 depends 'apt'

--- a/metadata.rb
+++ b/metadata.rb
@@ -48,8 +48,8 @@ attribute 'brightbox-ruby/gems',
  default: ["bundler", "rake", "rubygems-bundler"]
 
 attribute 'brightbox-ruby/rubygems_version',
- display_name: 'Rubygems version to enforce',
- description: 'Rubygems version to enforce',
+ display_name: 'The version of rubygems to enforce, or nil to use the default packaged version',
+ description: 'The version of rubygems to enforce, or nil to use the default packaged version',
  type: 'string',
  required: 'optional',
  recipes: ['brightbox-ruby'],

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,6 +28,14 @@ cookbook_file "/etc/gemrc" do
   mode   "0644"
 end
 
+if node['brightbox-ruby']['rubygems_version']
+  execute 'gem update --system' do
+    command "gem update -q --system '#{node['brightbox-ruby']['rubygems_version']}'"
+    environment 'REALLY_GEM_UPDATE_SYSTEM' => '1'
+    not_if "which gem && gem --version | grep -q '#{node['brightbox-ruby']['rubygems_version']}'"
+  end
+end
+
 node['brightbox-ruby']['gems'].each do |gem|
   gem_package gem do
     action node['brightbox-ruby']['default_action']

--- a/test/integration/rubygems/serverspec/localhost/rubygems_spec.rb
+++ b/test/integration/rubygems/serverspec/localhost/rubygems_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'rubygems' do
+  describe command('gem -v') do
+    it { should return_stdout /2.0.0/ }
+  end
+end

--- a/test/integration/rubygems/serverspec/spec_helper.rb
+++ b/test/integration/rubygems/serverspec/spec_helper.rb
@@ -1,0 +1,5 @@
+require 'serverspec'
+require 'pathname'
+
+include Serverspec::Helper::Exec
+include Serverspec::Helper::DetectOS


### PR DESCRIPTION
This lets you set desired version of rubygems regardless of which one is installed by the brightbox package.

Slightly off-topic: I used the new [chef-dk](http://www.getchef.com/downloads/chef-dk/) and there was an error trying to run `berks`, due to the hack in the metadata.rb file where it uses `Chef::Version`. The chef's version in chef-dk is actually 11.14.0.alpha.1 and cannot be parsed by `Chef::Version`. So I had to comment out all those attribute declarations to get specs to run (and add another spec). Regardless, that junk in metadata.rb should be removed, I will submit a separate pull request for that.
