### PR TITLE
Use ASCII apostrophes in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ For more documentation on these builds, please see [the official brightbox docum
 We encourage all community contributions. Keeping this in mind, please follow these general guidelines when contributing:
 
 * Fork the project
-* Create a topic branch for what you’re working on (git checkout -b awesome_feature)
+* Create a topic branch for what you're working on (git checkout -b awesome_feature)
 * Commit away, push that up (git push your\_remote awesome\_feature)
 * Create a new GitHub Issue with the commit, asking for review. Alternatively, send a pull request with details of what you added.
-* Once it’s accepted, if you want access to the core repository feel free to ask! Otherwise, you can continue to hack away in your own fork.
+* Once it's accepted, if you want access to the core repository feel free to ask! Otherwise, you can continue to hack away in your own fork.
 
 Other than that, our guidelines very closely match the GemCutter guidelines [here](http://wiki.github.com/qrush/gemcutter/contribution-guidelines).
 


### PR DESCRIPTION
After banging my head against this cryptic error:

```
Berkshelf::BerksError: Berks command Failed: /usr/bin/berks vendor $HOME/.berkshelf/default/vagrant/berkshelf-20150114-10925-1tw0lw-default --berksfile=$PWD/Berksfile, reason: /opt/chefdk/embedded/lib/ruby/2.1.0/json/common.rb:155:in `encode': "\xE2" on US-ASCII (Encoding::InvalidByteSequenceError)
```

which is in theory resolved by RiotGames/ridley#256, I traced the offending non-ASCII characters to the apostrophes in this README. I spent a little while trying to fix the root cause in ridley, but to no avail. It's something I'd like to do when I have more time, but this unblocks me for now, and will hopefully unblock other folks.
