### PR TITLE
Re-add ruby switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-# master
+# 1.2.2
+  * Ruby switch is back!  It has been added to the BrightBox repo (https://github.com/brightbox/deb-ruby2.1/issues/9#issuecomment-69098657)
 
 # 1.2.1
   * Fix character encoding issues in documentation (https://github.com/mojolingo/brightbox-ruby-cookbook/pull/3)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ For more documentation on these builds, please see [the official brightbox docum
 * `node['brightbox-ruby']['install_dev_package']` - Install the dev package, which provides headers for gem native extensions. Available options: `true`, `false`. Defaults to `true`.
 * `node['brightbox-ruby']['gems']` - Gems to be installed by default. Defaults to `["bundler", "rake", "rubygems-bundler"]`.
 * `node['brightbox-ruby']['rubygems_version']` - The version of rubygems to enforce, or nil to use the default packaged version. Defaults to `nil`.
-* `node['brightbox-ruby']['install_ruby_switch']` - Wether of not to install ruby_switch. Defaults to false on recent versions of Ubuntu (>= 14.x) since ruby_switch has been deprecated. Defaults to `false`.
 
 # Recipes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,4 +3,3 @@ default['brightbox-ruby']['version'] = '2.1'
 default['brightbox-ruby']['install_dev_package'] = true
 default['brightbox-ruby']['rubygems_version'] = nil
 default['brightbox-ruby']['gems'] = ["bundler", "rake", "rubygems-bundler"]
-default['brightbox-ruby']['install_ruby_switch'] = node['platform_version'].to_i < 14

--- a/metadata.rb
+++ b/metadata.rb
@@ -54,14 +54,6 @@ attribute 'brightbox-ruby/rubygems_version',
  recipes: ['brightbox-ruby'],
  default: nil
 
-attribute 'brightbox-ruby/install_ruby_switch',
- display_name: 'Wether of not to install ruby_switch',
- description: 'Wether of not to install ruby_switch. Defaults to false on recent versions of Ubuntu (>= 14.x) since ruby_switch has been deprecated.',
- type: 'boolean',
- required: 'optional',
- recipes: ['brightbox-ruby'],
- default: false
-
 supports 'ubuntu'
 
 depends 'apt'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -10,19 +10,16 @@ apt_repository "brightbox-ruby-ng-#{node['lsb']['codename']}" do
   notifies     :run, "execute[apt-get update]", :immediately
 end
 
-packages = ["build-essential", "ruby#{node['brightbox-ruby']['version']}"]
+packages = ["build-essential", "ruby#{node['brightbox-ruby']['version']}", "ruby-switch"]
 packages << "ruby#{node['brightbox-ruby']['version']}-dev" if node['brightbox-ruby']['install_dev_package']
-packages << "ruby-switch" if node['brightbox-ruby']['install_ruby_switch']
 packages.each do |name|
   apt_package name do
     action node['brightbox-ruby']['default_action']
   end
 end
 
-if node['brightbox-ruby']['install_ruby_switch']
-  execute "ruby-switch --set ruby#{node['brightbox-ruby']['version']}" do
-    not_if "ruby-switch --check | grep -q 'ruby#{node['brightbox-ruby']['version']}'"
-  end
+execute "ruby-switch --set ruby#{node['brightbox-ruby']['version']}" do
+  not_if "ruby-switch --check | grep -q 'ruby#{node['brightbox-ruby']['version']}'"
 end
 
 cookbook_file "/etc/gemrc" do


### PR DESCRIPTION
partial revert of dbd0f6c
Without ruby switch then after installing `$ ruby` remains unchanged (and I have to use `$ ruby2.1`).  You could just change the default but now it is in the [Brightbox PPA](https://github.com/brightbox/deb-ruby2.1/issues/9#issuecomment-69098657) I can't see why you wouldn't want to install it.
